### PR TITLE
remove instructions to dpeloy to heroku

### DIFF
--- a/sites/intro-to-rails/setting_the_default_page.step
+++ b/sites/intro-to-rails/setting_the_default_page.step
@@ -89,6 +89,4 @@ explanation {
   MARKDOWN
 }
 
-insert 'consider_deploying'
-
 next_step "rails_architecture"


### PR DESCRIPTION
Removing deploy link since heroku is no longer free and we will need to write up another doc to deploy to fly.io

Before: 
![Screenshot 2023-10-20 at 1 10 29 PM](https://github.com/railsbridge-boston/docs/assets/29336370/d3f40feb-b576-418c-b36b-753e00f4d40d)

After: 
![Screenshot 2023-10-20 at 1 10 34 PM](https://github.com/railsbridge-boston/docs/assets/29336370/54d295d0-8fc4-4545-9802-6c00999592aa)
