### PR TITLE
Fix some formatting on 1st page of Intro to Rails

### DIFF
--- a/sites/intro-to-rails/intro-to-rails.step
+++ b/sites/intro-to-rails/intro-to-rails.step
@@ -41,7 +41,8 @@ To get through this course, you'll need a free Github account.
 <a href="https://github.com/signup" target="_blank">Create a free Github account</a> by filling the signup form.
 <img class="screenshot" src="./img/codespaces1.png" />
 
-On the next screen, you can click "skip personalization" on the bottom to continue.<br>
+On the next screen, you can click <strong>Skip personalization</strong> on the bottom to continue.
+
 <img class="screenshot" src="./img/codespaces2.png" />
 
 <p>

--- a/sites/intro-to-rails/intro-to-rails.step
+++ b/sites/intro-to-rails/intro-to-rails.step
@@ -39,42 +39,46 @@ day. Probably.
 To get through this course, you'll need a free Github account.
 
 <a href="https://github.com/signup" target="_blank">Create a free Github account</a> by filling the signup form.
+
 <img class="screenshot" src="./img/codespaces1.png" />
 
 On the next screen, you can click <strong>Skip personalization</strong> on the bottom to continue.
 
 <img class="screenshot" src="./img/codespaces2.png" />
 
-<p>
-    Once you are signed into Github, you'll need to create a <strong>repository</strong> - a new programming project. <br><br>
-    To do that,
-    <a href="https://github.com/railsbridge-boston/start/generate" target="_blank">create a new repository from the RailsBridge template</a>.
-    You can pick any name you like, or accept the default suggestion. You can also decide if you want your code to be public
-    for anyone to see, or private. <br><br>Click <strong>Create repository</strong> to continue.<br>
-    <img class="screenshot" src="./img/codespaces5.png" />
-</p>
-<p>
-    It may take a moment for your repository to be generated.<br>
-    <img class="screenshot" src="./img/codespaces6.png" />
-</p>
-<p>
-    When it's finished, you'll be taken to a page that looks like this. Click on the green <strong>Code</strong> button,
-    make sure you're on the "Codespaces" tab,
-    then click <strong>Create codespace on main</strong>. This will be our code editor.<br>
-    <img class="screenshot" src="./img/codespaces7.png" />
-</p>
-<p>
-    This will begin setting up the editor in your browser. This usually takes at least 2 - 3 minutes.<br>
-    <img class="screenshot" src="./img/codespaces8.png" />
-</p>
-<p>
-    The editor will automatically set up like this once it's ready.<br>
-    <img class="screenshot" src="./img/codespaces9.png" />
-</p>
+Once you are signed into Github, you'll need to create a <strong>repository</strong> - a new programming project.
 
-<p>
-    Congratulations! You're ready to start coding.
-</p>
+To do that,
+<a href="https://github.com/railsbridge-boston/start/generate" target="_blank">create a new repository from the RailsBridge template</a>.
+
+You can pick any name you like, or accept the default suggestion. You can also decide if you want your code to be public
+for anyone to see, or private.
+
+Click <strong>Create repository</strong> to continue.
+
+<img class="screenshot" src="./img/codespaces5.png" />
+
+It may take a moment for your repository to be generated.
+
+<img class="screenshot" src="./img/codespaces6.png" />
+
+
+When it's finished, you'll be taken to a page that looks like this. Click on the green <strong>Code</strong> button,
+make sure you're on the "Codespaces" tab,
+then click <strong>Create codespace on main</strong>. This will be our code editor.
+
+<img class="screenshot" src="./img/codespaces7.png" />
+
+This will begin setting up the editor in your browser. This usually takes at least 2 - 3 minutes.
+
+<img class="screenshot" src="./img/codespaces8.png" />
+
+The editor will automatically set up like this once it's ready.
+
+<img class="screenshot" src="./img/codespaces9.png" />
+
+Congratulations! You're ready to start coding.
+
 
 MARKDOWN
 

--- a/sites/intro-to-rails/intro-to-rails.step
+++ b/sites/intro-to-rails/intro-to-rails.step
@@ -47,7 +47,7 @@ On the next screen, you can click "skip personalization" on the bottom to contin
 <p>
     Once you are signed into Github, you'll need to create a <strong>repository</strong> - a new programming project. <br><br>
     To do that,
-    <a href="https://github.com/railsbridge-boston/start/generate" target="_blank">Create a new repository</a> from the Railsbridge template.
+    <a href="https://github.com/railsbridge-boston/start/generate" target="_blank">create a new repository from the RailsBridge template</a>.
     You can pick any name you like, or accept the default suggestion. You can also decide if you want your code to be public
     for anyone to see, or private. <br><br>Click <strong>Create repository</strong> to continue.<br>
     <img class="screenshot" src="./img/codespaces5.png" />
@@ -58,7 +58,7 @@ On the next screen, you can click "skip personalization" on the bottom to contin
 </p>
 <p>
     When it's finished, you'll be taken to a page that looks like this. Click on the green <strong>Code</strong> button,
-    make sure you're on the "Codespaces" tab, 
+    make sure you're on the "Codespaces" tab,
     then click <strong>Create codespace on main</strong>. This will be our code editor.<br>
     <img class="screenshot" src="./img/codespaces7.png" />
 </p>


### PR DESCRIPTION
See individual commits for more details, but in summary:
- Make it more obvious that the repo should be created from a template
- Bold "skip personalization" instead of quoting
- Remove explicit `p` tags and rely on newlines to provide spacing

Here's some of the before and after:
![CleanShot 2023-10-20 at 22 21 03@2x](https://github.com/railsbridge-boston/docs/assets/602470/2feb37ec-7e9f-4f8a-b346-1a2ce227c194)
